### PR TITLE
Allow access to .well-known prefix (RFC-5785)

### DIFF
--- a/www/.htaccess
+++ b/www/.htaccess
@@ -11,6 +11,7 @@
 	# RewriteBase /
 
 	# prevents files starting with dot to be viewed by browser
+	RewriteCond %{REQUEST_URI} !^/.well-known/
 	RewriteRule /\.|^\. - [F]
 
 	# front controller


### PR DESCRIPTION
Default project configuration protect obvious private files by dot in filename. But some features using Well-Known Uniform Resource Identifiers (RFC-5785) defined in /.well-known/ prefix. This features can be designed outside of any Nette application (for example: Letsencrypt project is runned from server shell and puts static files to `./.well-known/` webroot as verification process during requesting HTTPS certificate). Default configuration of Nette project can thwart this process.

I know its contentious PR, but current state make confusions on some webhostings.
