### PR TITLE
.htaccess: Apache 2.4 compatibility

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,2 +1,1 @@
-Order Allow,Deny
-Deny from all
+Require all denied

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -1,5 +1,5 @@
 # Apache configuration file (see https://httpd.apache.org/docs/current/mod/quickreference.html)
-Allow from all
+Require all granted
 
 # disable directory listing
 <IfModule mod_autoindex.c>


### PR DESCRIPTION
Apache 2.4 introduced `mod_authz_core` with `Require` directive. Directives `Order`, `Allow` and `Deny` are from `mod_access_compat` which may not be loaded.

https://httpd.apache.org/docs/2.4/upgrading.html#access

IMHO, Apache 2.4 is standard now, but still not sure, this should be unconditional. Maybe...
```
<IfModule mod_authz_core.c>
    Require all granted
</IfModule>
<IfModule !mod_authz_core.c>
    Order deny,allow
    Allow from all
</IfModule>
```
(https://serverfault.com/questions/576755/write-an-apache-configuration-with-condition-based-on-the-apache-version)

What you think? I'll send PR to nette/sanbox after.
