### PR TITLE
added netteForms JS integrity checksum

### DIFF
--- a/app/presenters/templates/@layout.latte
+++ b/app/presenters/templates/@layout.latte
@@ -13,7 +13,7 @@
 	{include content}
 
 	{block scripts}
-	<script src="https://nette.github.io/resources/js/3/netteForms.min.js"></script>
+	<script src="https://nette.github.io/resources/js/3/netteForms.min.js" integrity="sha384-9wkxWtTS1c0O/eVffa0CYABRZALgxKHyq2Urv/wjXrf62uurHkk7yf++0BlKh33V" crossorigin="anonymous"></script>
 	{/block}
 </body>
 </html>


### PR DESCRIPTION
This pull request is about adding Javascript's integrity checksum (SRI) into template of Nette project - because netteForms is loaded from CDN (nette.github.io).

There is more informations about SRI:
https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity

